### PR TITLE
Feature: MoveIt!-Gazebo Integration

### DIFF
--- a/blue_moveit_config/.setup_assistant
+++ b/blue_moveit_config/.setup_assistant
@@ -1,7 +1,7 @@
 moveit_setup_assistant_config:
   URDF:
     package: blue_descriptions
-    relative_path: robots/blue_full.urdf.xacro
+    relative_path: robots/blue_full_v2.urdf.xacro
     xacro_args: "--inorder "
   SRDF:
     relative_path: config/blue_full.srdf

--- a/blue_moveit_config/config/blue_full.srdf
+++ b/blue_moveit_config/config/blue_full.srdf
@@ -130,4 +130,22 @@
     <disable_collisions link1="right_shoulder_lift_link" link2="right_wrist_lift_link" reason="Never" />
     <disable_collisions link1="right_shoulder_lift_link" link2="right_wrist_roll_link" reason="Never" />
     <disable_collisions link1="right_wrist_lift_link" link2="right_wrist_roll_link" reason="Adjacent" />
+
+    <disable_collisions link1="left_end_roll_link" link2="left_r_finger_link" reason="Adjacent" />
+    <disable_collisions link1="left_end_roll_link" link2="left_l_finger_link" reason="Adjacent" />
+    <disable_collisions link1="left_r_finger_link" link2="left_l_finger_link" reason="Adjacent" />
+    <disable_collisions link1="left_r_finger_link" link2="left_r_finger_tip_link" reason="Adjacent" />
+    <disable_collisions link1="left_r_finger_link" link2="left_l_finger_tip_link" reason="Adjacent" />
+    <disable_collisions link1="left_l_finger_link" link2="left_r_finger_tip_link" reason="Adjacent" />
+    <disable_collisions link1="left_l_finger_link" link2="left_l_finger_tip_link" reason="Adjacent" />
+
+    <disable_collisions link1="right_end_roll_link" link2="right_r_finger_link" reason="Adjacent" />
+    <disable_collisions link1="right_end_roll_link" link2="right_l_finger_link" reason="Adjacent" />
+    <disable_collisions link1="right_r_finger_link" link2="right_r_finger_tip_link" reason="Adjacent" />
+    <disable_collisions link1="right_r_finger_link" link2="right_l_finger_tip_link" reason="Adjacent" />
+    <disable_collisions link1="right_l_finger_link" link2="right_r_finger_tip_link" reason="Adjacent" />
+    <disable_collisions link1="right_l_finger_link" link2="right_l_finger_tip_link" reason="Adjacent" />
+
+    <disable_collisions link1="right_r_finger_tip_link" link2="right_l_finger_tip_link" reason="Adjacent" />
+    <disable_collisions link1="left_r_finger_tip_link" link2="left_l_finger_tip_link" reason="Adjacent" />
 </robot>

--- a/blue_moveit_config/config/blue_full.srdf
+++ b/blue_moveit_config/config/blue_full.srdf
@@ -17,6 +17,7 @@
         <joint name="left_base_roll_joint" />
         <joint name="left_shoulder_lift_joint" />
         <joint name="left_shoulder_roll_joint" />
+        <joint name="left_gripper_joint" />
     </group>
     <group name="right_gripper">
         <joint name="right_gripper_joint" />
@@ -32,6 +33,7 @@
         <joint name="right_base_roll_joint" />
         <joint name="right_shoulder_lift_joint" />
         <joint name="right_shoulder_roll_joint" />
+        <joint name="right_gripper_joint" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="home" group="left_arm">

--- a/blue_moveit_config/config/blue_full_moveit_controllers.yaml
+++ b/blue_moveit_config/config/blue_full_moveit_controllers.yaml
@@ -1,5 +1,5 @@
 controller_list:
-  - name: left_arm/blue_controllers/joint_torque_controller
+  - name: left_arm/blue_controllers/joint_trajectory_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
     allow_partial_joints_goal: true
@@ -39,7 +39,7 @@ controller_list:
         trajectory: 0.05
         goal: 0.02
 
-  - name: right_arm/blue_controllers/joint_torque_controller
+  - name: right_arm/blue_controllers/joint_trajectory_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
     allow_partial_joints_goal: true

--- a/blue_moveit_config/config/blue_moveit_controllers.yaml
+++ b/blue_moveit_config/config/blue_moveit_controllers.yaml
@@ -1,0 +1,94 @@
+controller_list:
+  - name: left_arm/blue_controllers/joint_torque_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    allow_partial_joints_goal: true
+    default: true
+    joints:
+      - left_base_roll_joint
+      - left_shoulder_lift_joint
+      - left_shoulder_roll_joint
+      - left_elbow_lift_joint
+      - left_elbow_roll_joint
+      - left_wrist_lift_joint
+      - left_wrist_roll_joint
+    constraints:
+      goal_time: 0.5
+      left_base_roll_joint:
+        trajectory: 0.05
+        goal: 0.02
+      left_shoulder_lift_joint:
+        trajectory: 0.05
+        goal: 0.02
+      left_shoulder_roll_joint:
+        trajectory: 0.05
+        goal: 0.02
+      left_elbow_lift_joint:
+        trajectory: 0.05
+        goal: 0.02
+      left_elbow_roll_joint:
+        trajectory: 0.05
+        goal: 0.02
+      left_wrist_lift_joint:
+        trajectory: 0.05
+        goal: 0.02
+      left_wrist_roll_joint:
+        trajectory: 0.05
+        goal: 0.02
+      left_gripper_joint:
+        trajectory: 0.05
+        goal: 0.02
+
+  - name: right_arm/blue_controllers/joint_torque_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    allow_partial_joints_goal: true
+    default: true
+    joints:
+      - right_base_roll_joint
+      - right_shoulder_lift_joint
+      - right_shoulder_roll_joint
+      - right_elbow_lift_joint
+      - right_elbow_roll_joint
+      - right_wrist_lift_joint
+      - right_wrist_roll_joint
+    constraints:
+      goal_time: 0.5
+      right_base_roll_joint:
+        trajectory: 0.05
+        goal: 0.02
+      right_shoulder_lift_joint:
+        trajectory: 0.05
+        goal: 0.02
+      right_shoulder_roll_joint:
+        trajectory: 0.05
+        goal: 0.02
+      right_elbow_lift_joint:
+        trajectory: 0.05
+        goal: 0.02
+      right_elbow_roll_joint:
+        trajectory: 0.05
+        goal: 0.02
+      right_wrist_lift_joint:
+        trajectory: 0.05
+        goal: 0.02
+      right_wrist_roll_joint:
+        trajectory: 0.05
+        goal: 0.02
+      right_gripper_joint:
+        trajectory: 0.05
+        goal: 0.02
+
+  - name: left_arm/blue_controllers/gripper_controller
+    action_ns: gripper_cmd
+    type: GripperCommand
+    default: true
+    joints:
+      - left_gripper_joint
+
+  - name: right_arm/blue_controllers/gripper_controller
+    action_ns: gripper_cmd
+    type: GripperCommand
+    default: true
+    joints:
+      - right_gripper_joint

--- a/blue_moveit_config/config/kinematics.yaml
+++ b/blue_moveit_config/config/kinematics.yaml
@@ -2,9 +2,7 @@ left_arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3
 right_arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3

--- a/blue_moveit_config/config/ompl_planning.yaml
+++ b/blue_moveit_config/config/ompl_planning.yaml
@@ -20,7 +20,7 @@ planner_configs:
   KPIECE:
     type: geometric::KPIECE
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
     failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
     min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
@@ -44,7 +44,7 @@ planner_configs:
     temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
     min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
     init_temperature: 10e-6  # initial temperature. default: 10e-6
-    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
     frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
     k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRM:
@@ -75,9 +75,9 @@ planner_configs:
   STRIDE:
     type: geometric::STRIDE
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     use_projected_distance: 0  # whether nearest neighbors are computed based on distances in a projection of the state rather distances in the state space itself. default: 0
-    degree: 16  # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16 
+    degree: 16  # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16
     max_degree: 18  # max degree of a node in the GNAT. default: 12
     min_degree: 12  # min degree of a node in the GNAT. default: 12
     max_pts_per_leaf: 6  # max points per leaf in the GNAT. default: 6
@@ -88,13 +88,13 @@ planner_configs:
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
     temp_change_factor: 0.1  # how much to increase or decrease temp. default: 0.1
     init_temperature: 100  # initial temperature. default: 100
-    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
     frountier_node_ratio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
     cost_threshold: 1e300  # the cost threshold. Any motion cost that is not better will not be expanded. default: inf
   LBTRRT:
     type: geometric::LBTRRT
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     epsilon: 0.4  # optimality approximation factor. default: 0.4
   BiEST:
     type: geometric::BiEST
@@ -102,7 +102,7 @@ planner_configs:
   ProjEST:
     type: geometric::ProjEST
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LazyPRM:
     type: geometric::LazyPRM
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
@@ -121,110 +121,110 @@ planner_configs:
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
 left_arm:
-  default_planner_config: NkConfigDefault
+  default_planner_config: RRTConnect
   planner_configs:
-    - SBLkConfigDefault
-    - ESTkConfigDefault
-    - LBKPIECEkConfigDefault
-    - BKPIECEkConfigDefault
-    - KPIECEkConfigDefault
-    - RRTkConfigDefault
-    - RRTConnectkConfigDefault
-    - RRTstarkConfigDefault
-    - TRRTkConfigDefault
-    - PRMkConfigDefault
-    - PRMstarkConfigDefault
-    - FMTkConfigDefault
-    - BFMTkConfigDefault
-    - PDSTkConfigDefault
-    - STRIDEkConfigDefault
-    - BiTRRTkConfigDefault
-    - LBTRRTkConfigDefault
-    - BiESTkConfigDefault
-    - ProjESTkConfigDefault
-    - LazyPRMkConfigDefault
-    - LazyPRMstarkConfigDefault
-    - SPARSkConfigDefault
-    - SPARStwokConfigDefault
+    - SBL
+    - EST
+    - LBKPIECE
+    - BKPIECE
+    - KPIECE
+    - RRT
+    - RRTConnect
+    - RRTstar
+    - TRRT
+    - PRM
+    - PRMstar
+    - FMT
+    - BFMT
+    - PDST
+    - STRIDE
+    - BiTRRT
+    - LBTRRT
+    - BiEST
+    - ProjEST
+    - LazyPRM
+    - LazyPRMstar
+    - SPARS
+    - SPARStwo
   projection_evaluator: joints(left_base_roll_joint,left_shoulder_lift_joint)
   longest_valid_segment_fraction: 0.005
 right_gripper:
-  default_planner_config: kConfigDefault
+  default_planner_config: RRTConnect
   planner_configs:
-    - SBLkConfigDefault
-    - ESTkConfigDefault
-    - LBKPIECEkConfigDefault
-    - BKPIECEkConfigDefault
-    - KPIECEkConfigDefault
-    - RRTkConfigDefault
-    - RRTConnectkConfigDefault
-    - RRTstarkConfigDefault
-    - TRRTkConfigDefault
-    - PRMkConfigDefault
-    - PRMstarkConfigDefault
-    - FMTkConfigDefault
-    - BFMTkConfigDefault
-    - PDSTkConfigDefault
-    - STRIDEkConfigDefault
-    - BiTRRTkConfigDefault
-    - LBTRRTkConfigDefault
-    - BiESTkConfigDefault
-    - ProjESTkConfigDefault
-    - LazyPRMkConfigDefault
-    - LazyPRMstarkConfigDefault
-    - SPARSkConfigDefault
-    - SPARStwokConfigDefault
+    - SBL
+    - EST
+    - LBKPIECE
+    - BKPIECE
+    - KPIECE
+    - RRT
+    - RRTConnect
+    - RRTstar
+    - TRRT
+    - PRM
+    - PRMstar
+    - FMT
+    - BFMT
+    - PDST
+    - STRIDE
+    - BiTRRT
+    - LBTRRT
+    - BiEST
+    - ProjEST
+    - LazyPRM
+    - LazyPRMstar
+    - SPARS
+    - SPARStwo
 left_gripper:
-  default_planner_config: kConfigDefault
+  default_planner_config: RRTConnect
   planner_configs:
-    - SBLkConfigDefault
-    - ESTkConfigDefault
-    - LBKPIECEkConfigDefault
-    - BKPIECEkConfigDefault
-    - KPIECEkConfigDefault
-    - RRTkConfigDefault
-    - RRTConnectkConfigDefault
-    - RRTstarkConfigDefault
-    - TRRTkConfigDefault
-    - PRMkConfigDefault
-    - PRMstarkConfigDefault
-    - FMTkConfigDefault
-    - BFMTkConfigDefault
-    - PDSTkConfigDefault
-    - STRIDEkConfigDefault
-    - BiTRRTkConfigDefault
-    - LBTRRTkConfigDefault
-    - BiESTkConfigDefault
-    - ProjESTkConfigDefault
-    - LazyPRMkConfigDefault
-    - LazyPRMstarkConfigDefault
-    - SPARSkConfigDefault
-    - SPARStwokConfigDefault
+    - SBL
+    - EST
+    - LBKPIECE
+    - BKPIECE
+    - KPIECE
+    - RRT
+    - RRTConnect
+    - RRTstar
+    - TRRT
+    - PRM
+    - PRMstar
+    - FMT
+    - BFMT
+    - PDST
+    - STRIDE
+    - BiTRRT
+    - LBTRRT
+    - BiEST
+    - ProjEST
+    - LazyPRM
+    - LazyPRMstar
+    - SPARS
+    - SPARStwo
 right_arm:
-  default_planner_config: NonekConfigDefault
+  default_planner_config: RRTConnect
   planner_configs:
-    - SBLkConfigDefault
-    - ESTkConfigDefault
-    - LBKPIECEkConfigDefault
-    - BKPIECEkConfigDefault
-    - KPIECEkConfigDefault
-    - RRTkConfigDefault
-    - RRTConnectkConfigDefault
-    - RRTstarkConfigDefault
-    - TRRTkConfigDefault
-    - PRMkConfigDefault
-    - PRMstarkConfigDefault
-    - FMTkConfigDefault
-    - BFMTkConfigDefault
-    - PDSTkConfigDefault
-    - STRIDEkConfigDefault
-    - BiTRRTkConfigDefault
-    - LBTRRTkConfigDefault
-    - BiESTkConfigDefault
-    - ProjESTkConfigDefault
-    - LazyPRMkConfigDefault
-    - LazyPRMstarkConfigDefault
-    - SPARSkConfigDefault
-    - SPARStwokConfigDefault
+    - SBL
+    - EST
+    - LBKPIECE
+    - BKPIECE
+    - KPIECE
+    - RRT
+    - RRTConnect
+    - RRTstar
+    - TRRT
+    - PRM
+    - PRMstar
+    - FMT
+    - BFMT
+    - PDST
+    - STRIDE
+    - BiTRRT
+    - LBTRRT
+    - BiEST
+    - ProjEST
+    - LazyPRM
+    - LazyPRMstar
+    - SPARS
+    - SPARStwo
   projection_evaluator: joints(right_base_roll_joint,right_shoulder_lift_joint)
   longest_valid_segment_fraction: 0.005

--- a/blue_moveit_config/launch/blue_full_moveit_controller_manager.launch.xml
+++ b/blue_moveit_config/launch/blue_full_moveit_controller_manager.launch.xml
@@ -2,6 +2,7 @@
   <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
   <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
   <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
+
   <!-- load controller_list -->
-  <rosparam file="$(find blue_moveit_config)/config/blue_moveit_controllers.yaml"/>
+  <rosparam file="$(find blue_moveit_config)/config/blue_full_moveit_controllers.yaml"/>
  </launch>

--- a/blue_moveit_config/launch/blue_full_moveit_controller_manager.launch.xml
+++ b/blue_moveit_config/launch/blue_full_moveit_controller_manager.launch.xml
@@ -1,3 +1,7 @@
-<launch>
-
-</launch>
+ <launch>
+  <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
+  <arg name="moveit_controller_manager" default="moveit_simple_controller_manager/MoveItSimpleControllerManager" />
+  <param name="moveit_controller_manager" value="$(arg moveit_controller_manager)"/>
+  <!-- load controller_list -->
+  <rosparam file="$(find blue_moveit_config)/config/blue_moveit_controllers.yaml"/>
+ </launch>

--- a/blue_moveit_config/launch/gazebo_demo.launch
+++ b/blue_moveit_config/launch/gazebo_demo.launch
@@ -1,0 +1,15 @@
+<launch>
+    <arg name="version" default="2" doc="1 or 2" />
+
+    <!-- Init Blue Simulator -->
+    <include file="$(find blue_gazebo)/launch/blue_pickup_world.launch"/>
+
+    <!-- Load MoveIt! Stack -->
+    <include file="$(find blue_moveit_config)/launch/planning_context.launch">
+        <arg name="load_robot_description" value="false"/>
+    </include>
+
+    <include file="$(find blue_moveit_config)/launch/move_group.launch" />
+
+    <node name="joint_state_desired_publisher" pkg="topic_tools" type="relay" args="joint_states joint_states_desired" />
+</launch>

--- a/blue_moveit_config/launch/move_group.launch
+++ b/blue_moveit_config/launch/move_group.launch
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="blue_side" default="blue_full" />
 
   <include file="$(find blue_moveit_config)/launch/planning_context.launch" />
 
@@ -28,13 +29,13 @@
   <!-- Trajectory Execution Functionality -->
   <include ns="move_group" file="$(find blue_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
-    <arg name="moveit_controller_manager" value="blue_full" unless="$(arg fake_execution)"/>
+    <arg name="moveit_controller_manager" value="$(arg blue_side)" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
   </include>
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find blue_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="blue_full" />
+    <arg name="moveit_sensor_manager" value="$(arg blue_side)" />
   </include>
 
   <!-- Start the actual move_group node/action server -->

--- a/blue_moveit_config/launch/planning_context.launch
+++ b/blue_moveit_config/launch/planning_context.launch
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="blue_side" default="blue_full" />
+
   <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
   <arg name="load_robot_description" default="false"/>
 
@@ -6,10 +8,10 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="xacro --inorder  '$(find blue_descriptions)/robots/blue_full_v2.urdf.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="xacro --inorder  '$(find blue_descriptions)/robots/$(arg blue_side)_v2.urdf.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
-  <param name="$(arg robot_description)_semantic" textfile="$(find blue_moveit_config)/config/blue_full.srdf" />
+  <param name="$(arg robot_description)_semantic" textfile="$(find blue_moveit_config)/config/$(arg blue_side).srdf" />
 
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">

--- a/blue_moveit_config/launch/planning_context.launch
+++ b/blue_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="xacro --inorder  '$(find blue_descriptions)/robots/blue_full.urdf.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="xacro --inorder  '$(find blue_descriptions)/robots/blue_full_v2.urdf.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find blue_moveit_config)/config/blue_full.srdf" />

--- a/blue_moveit_scenarios/CMakeLists.txt
+++ b/blue_moveit_scenarios/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(blue_moveit_scenarios)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++14)
+set(GCC_COVERAGE_COMPILE_FLAGS "-fpermissive")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} ${GAZEBO_CXX_FLAGS}" )
+
+find_package(catkin REQUIRED COMPONENTS
+  controller_manager
+  effort_controllers
+  gazebo_ros
+  joint_state_controller
+  joint_state_publisher
+  joint_trajectory_controller
+  robot_state_publisher
+  roscpp
+  std_msgs
+  tf
+  xacro
+  moveit_core
+  moveit_visual_tools
+  moveit_ros_planning
+  moveit_ros_planning_interface
+  actionlib
+  actionlib_msgs
+)
+
+catkin_package(
+  INCLUDE_DIRS src
+  CATKIN_DEPENDS roscpp actionlib_msgs
+)
+
+find_package(Boost REQUIRED COMPONENTS filesystem)
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(JSONCPP jsoncpp)
+message(${JSONCPP_LIBRARIES})
+
+catkin_package(
+  CATKIN_DEPENDS 
+  moveit_core
+  moveit_visual_tools
+  moveit_ros_planning_interface
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(pick_and_place src/pick_and_place.cpp)
+add_library(moveit_arm_utils include/moveit_arm_utils.cpp)
+target_link_libraries(pick_and_place moveit_arm_utils ${catkin_LIBRARIES})
+
+add_dependencies(pick_and_place moveit_arm_utils ${blue_moveit_gazebo_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/blue_moveit_scenarios/include/moveit_arm_utils.cpp
+++ b/blue_moveit_scenarios/include/moveit_arm_utils.cpp
@@ -1,0 +1,89 @@
+#include "moveit_arm_utils.h"
+
+void actuateGripper(actionlib::SimpleActionClient<control_msgs::GripperCommandAction>& ac, double position, double max_effort)
+{
+    // Function for actuating grippers. Pass in the appropriate action client.
+    control_msgs::GripperCommandGoal goal;
+
+    goal.command.position = position;
+    goal.command.max_effort = max_effort;
+
+    ac.sendGoal(goal);
+    ROS_INFO("Sent Gripper Command: Position %f | Max Effort %f", position, max_effort);
+
+    bool finished_before_timeout = ac.waitForResult(ros::Duration(30.0));
+
+    if (finished_before_timeout)
+    {
+      actionlib::SimpleClientGoalState state = ac.getState();
+      ROS_INFO("Action finished: %s",state.toString().c_str());
+    }
+    else
+      ROS_INFO("Action did not finish before the time out.");
+}
+
+void moveArm(actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction>& ac,
+             moveit::planning_interface::MoveGroupInterface& move_group,
+             geometry_msgs::Pose pose,
+             const ros::Duration& goal_time_tolerance)
+{
+    control_msgs::FollowJointTrajectoryGoal goal;
+    moveit::planning_interface::MoveGroupInterface::Plan plan;
+
+    move_group.setPoseTarget(pose);
+    move_group.plan(plan);
+
+    plan.trajectory_.joint_trajectory.joint_names.pop_back();
+
+    goal.trajectory = plan.trajectory_.joint_trajectory;
+    goal.goal_time_tolerance = goal_time_tolerance;
+
+    ac.sendGoal(goal);
+    ROS_INFO("Sent arm Command");
+
+    bool finished_before_timeout = ac.waitForResult(ros::Duration(30.0));
+
+    if (finished_before_timeout)
+    {
+      actionlib::SimpleClientGoalState state = ac.getState();
+      ROS_INFO("Action finished: %s",state.toString().c_str());
+    }
+    else
+      ROS_INFO("Action did not finish before the time out.");
+}
+
+void add_primitive_collision(const shape_msgs::SolidPrimitive& _shape_msg, const geometry_msgs::Pose& _pose,
+                             const std::string& _frame_name, const std::string& _id,
+                             std::vector<moveit_msgs::CollisionObject>& _collision_objects)
+{
+    moveit_msgs::CollisionObject collision_object;
+
+    collision_object.header.frame_id = _frame_name;
+    collision_object.id = _id;
+    collision_object.primitives.push_back(_shape_msg);
+    collision_object.primitive_poses.push_back(_pose);
+    collision_object.operation = collision_object.ADD;
+
+    _collision_objects.push_back(collision_object);
+}
+
+shape_msgs::SolidPrimitive create_box_shape(const double& _x, const double& _y, const double& _z)
+{
+  shape_msgs::SolidPrimitive msg;
+  msg.type = msg.BOX;
+  msg.dimensions.resize(3);
+  msg.dimensions[msg.BOX_X] = _x;
+  msg.dimensions[msg.BOX_Y] = _y;
+  msg.dimensions[msg.BOX_Z] = _z;
+  return msg;
+}
+
+shape_msgs::SolidPrimitive create_cylinder_shape(const double& _r, const double& _h)
+{
+  shape_msgs::SolidPrimitive msg;
+  msg.type = msg.CYLINDER;
+  msg.dimensions.resize(2);
+  msg.dimensions[msg.CYLINDER_RADIUS] = _r;
+  msg.dimensions[msg.CYLINDER_HEIGHT] = _h;
+  return msg;
+}

--- a/blue_moveit_scenarios/include/moveit_arm_utils.h
+++ b/blue_moveit_scenarios/include/moveit_arm_utils.h
@@ -1,0 +1,38 @@
+#ifndef MOVEIT_ARM_UTILS
+#define MOVEIT_ARM_UTILS
+
+// ROS
+#include <ros/ros.h>
+#include <actionlib/client/simple_action_client.h>
+#include <actionlib/client/terminal_state.h>
+#include <control_msgs/GripperCommandAction.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
+
+// MoveIt!
+#include <moveit/move_group_interface/move_group_interface.h>
+#include <moveit/planning_scene_interface/planning_scene_interface.h>
+
+#include <moveit_msgs/RobotTrajectory.h>
+#include <moveit_msgs/DisplayRobotState.h>
+#include <moveit_msgs/DisplayTrajectory.h>
+
+#include <moveit_msgs/AttachedCollisionObject.h>
+#include <moveit_msgs/CollisionObject.h>
+
+#include "geometric_shapes/shapes.h"
+
+void actuateGripper(actionlib::SimpleActionClient<control_msgs::GripperCommandAction>& ac, double position, double max_effort);
+
+void moveArm(actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction>& ac,
+             moveit::planning_interface::MoveGroupInterface& move_group,
+             geometry_msgs::Pose pose,
+             const ros::Duration& goal_time_tolerance);
+
+void add_primitive_collision(const shape_msgs::SolidPrimitive& _shape_msg, const geometry_msgs::Pose& _pose,
+                             const std::string& _frame_name, const std::string& _id,
+                             std::vector<moveit_msgs::CollisionObject>& _collision_objects);
+
+shape_msgs::SolidPrimitive create_box_shape(const double& _x, const double& _y, const double& _z);
+shape_msgs::SolidPrimitive create_cylinder_shape(const double& _r, const double& _h);
+
+#endif

--- a/blue_moveit_scenarios/package.xml
+++ b/blue_moveit_scenarios/package.xml
@@ -1,0 +1,48 @@
+<package>
+
+  <name>blue_moveit_scenarios</name>
+  <version>0.3.0</version>
+  <description>
+     Berkeley Blue Arm MoveIt Demo Scenarios
+  </description>
+  <author email="methyldragon@gmail.com">methylDragon</author>
+  <maintainer email="methyldragon@gmail.com">methylDragon</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  
+  <build_depend>controller_manager</build_depend>
+  <build_depend>effort_controllers</build_depend>
+  <build_depend>gazebo_ros</build_depend>
+  <build_depend>gazebo_ros_control</build_depend>
+  <build_depend>joint_state_controller</build_depend>
+  <build_depend>joint_state_publisher</build_depend>
+  <build_depend>joint_trajectory_controller</build_depend>
+  <build_depend>robot_state_publisher</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>xacro</build_depend>
+  <build_depend>libjsoncpp-dev</build_depend>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+
+  <run_depend>roscpp</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
+
+  <run_depend>moveit_core</run_depend>
+  <build_depend>moveit_core</build_depend>
+
+  <run_depend>moveit_ros_planning_interface</run_depend>
+  <build_depend>moveit_ros_planning_interface</build_depend>
+
+  <run_depend>moveit_perception</run_depend>
+  <build_depend>moveit_perception</build_depend>
+
+  <run_depend>moveit_visual_tools</run_depend>
+  <build_depend>moveit_visual_tools</build_depend>
+
+</package>

--- a/blue_moveit_scenarios/src/pick_and_place.cpp
+++ b/blue_moveit_scenarios/src/pick_and_place.cpp
@@ -1,0 +1,181 @@
+#include "moveit_arm_utils.h"
+
+// Gripper params
+const double CLOSE_POS(0.61);
+const double OPEN_POS(0.1);
+const double MAX_EFFORT(10.2);
+
+// Workspace constraints
+const double BASE_LINK_HEIGHT(0.965);
+
+// Movement params
+ros::Duration GOAL_TIME_TOLERANCE(15.0);
+const double GOAL_TOLERANCE(0.025);
+const double PRE_GRASP_APPROACH_DISTANCE(0.10);
+const double PRE_GRASP_DISTANCE(0.04);
+const double POST_GRASP_RETREAT_DISTANCE(0.10);
+
+int main(int argc, char **argv)
+{
+    // Vars
+    std::vector<moveit_msgs::CollisionObject> collision_objects;
+
+    // Init ROS
+    ros::init(argc, argv, "pick_and_place_commander");
+    ros::NodeHandle nh;
+
+    // Start async spinner to facilitate joint-state publishing
+    ros::AsyncSpinner spinner(1);
+    spinner.start();
+
+    // Init Planning Interfaces
+    moveit::planning_interface::MoveGroupInterface l_move_group("left_arm");
+    moveit::planning_interface::MoveGroupInterface r_move_group("right_arm");
+    moveit::planning_interface::PlanningSceneInterface planning_scene_interface;
+
+    // Get Joint Model Groups
+    // const robot_state::JointModelGroup* l_joint_model_group = l_move_group.getCurrentState()->getJointModelGroup("left_arm");
+    // const robot_state::JointModelGroup* r_joint_model_group = r_move_group.getCurrentState()->getJointModelGroup("right_arm");
+
+    // Print all groups in the robot
+    // ROS_INFO("Available Planning Groups:");
+    // std::copy(l_move_group.getJointNames().begin(), l_move_group.getJointNames().end(),
+    //       std::ostream_iterator<std::string>(std::cout, ", "));
+
+    ROS_INFO("Interfaces initialised.");
+
+    ROS_INFO("L Planning frame: %s", l_move_group.getPlanningFrame().c_str());
+    ROS_INFO("R Planning frame: %s", r_move_group.getPlanningFrame().c_str());
+
+    // Init Gripper action clients
+    actionlib::SimpleActionClient<control_msgs::GripperCommandAction> right_gripper_client("right_arm/blue_controllers/gripper_controller/gripper_cmd", true);
+    actionlib::SimpleActionClient<control_msgs::GripperCommandAction> left_gripper_client("left_arm/blue_controllers/gripper_controller/gripper_cmd", true);
+
+    left_gripper_client.waitForServer();
+    right_gripper_client.waitForServer();
+
+    ROS_INFO("Gripper action clients ready!");
+
+    // Init Arm action clients
+    actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> right_arm_client("right_arm/blue_controllers/joint_torque_controller/follow_joint_trajectory", true);
+    actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> left_arm_client("left_arm/blue_controllers/joint_torque_controller/follow_joint_trajectory", true);
+
+    left_arm_client.waitForServer();
+    right_arm_client.waitForServer();
+
+    ROS_INFO("Arm action clients ready!");
+
+    ////////////////////////////////////////////////////////////////////////////
+    // POPULATE ENVIRONMENT
+    ////////////////////////////////////////////////////////////////////////////
+
+    // // Populate environment with box
+    // shape_msgs::SolidPrimitive pickup_box_shape = create_box_shape(0.07, 0.07, 0.2);
+    //
+    // // Note: The pose is located at the CENTER of the primitive. So adjust accordingly
+    // // For URDFs, Pose is generally located at the BOTTOM of the model.
+    // // Also take note that for MoveIt in this case, the fixed frame is base_link, which is different from
+    // // the URDF's world_link frame.
+    //
+    // // Base_link height is 0.965
+    // geometry_msgs::Pose box_pose;
+    // box_pose.orientation.w = 1.0;
+    // box_pose.position.x = 0.8;
+    // box_pose.position.y = 0.4;
+    // box_pose.position.z = 0.8 - BASE_LINK_HEIGHT + 0.2 / 2; // Box falls to table height at 0.8.
+    //
+    // add_primitive_collision(pickup_box_shape, box_pose, l_move_group.getPlanningFrame(),
+    //                         "pickup_box", collision_objects);
+
+    // Populate environment with cylinder
+    shape_msgs::SolidPrimitive pickup_cylinder_shape = create_cylinder_shape(0.025, 0.2);
+
+    geometry_msgs::Pose cylinder_pose;
+    cylinder_pose.orientation.w = 1.0;
+    cylinder_pose.position.x = 0.8;
+    cylinder_pose.position.y = 0.4;
+    cylinder_pose.position.z = 0.8 - BASE_LINK_HEIGHT + 0.2 / 2; // Box falls to table height at 0.8.
+
+    add_primitive_collision(pickup_cylinder_shape, cylinder_pose, l_move_group.getPlanningFrame(),
+                            "pickup_cylinder", collision_objects);
+
+    // Populate environment with table
+    shape_msgs::SolidPrimitive table_shape = create_box_shape(1.0, 2.0, 0.075);
+
+    geometry_msgs::Pose table_pose;
+    table_pose.orientation.w = 1.0;
+    table_pose.position.x = 0.58;
+    table_pose.position.y = 0;
+    table_pose.position.z = 0.8 - BASE_LINK_HEIGHT - 0.075 / 2;
+
+    add_primitive_collision(table_shape, table_pose, l_move_group.getPlanningFrame(),
+                            "table", collision_objects);
+
+    // Populate planning interface
+    planning_scene_interface.addCollisionObjects(collision_objects);
+
+    ROS_INFO("Waiting for arm to stabilise...");
+    ros::Duration(3).sleep();
+
+    // Open grippers
+    ROS_INFO("Opening grippers");
+    actuateGripper(left_gripper_client, OPEN_POS, MAX_EFFORT);
+    actuateGripper(right_gripper_client, OPEN_POS, MAX_EFFORT);
+
+    ROS_INFO("MoveIt! Interfaces start states initialised!");
+
+    // Move left arm to pick up box
+    geometry_msgs::Pose box_pickup_pose;
+
+    box_pickup_pose.orientation.w = 0.685497; // HORIzONTAL POSE IS ACTUALLY 45 degrees pitch
+    box_pickup_pose.orientation.x = 0.652666;
+    box_pickup_pose.orientation.y = -0.229109;
+    box_pickup_pose.orientation.z = 0.227221;
+
+    box_pickup_pose.position.x = 0.8 - PRE_GRASP_APPROACH_DISTANCE;
+    box_pickup_pose.position.y = 0.4;
+    box_pickup_pose.position.z = 0.8 - BASE_LINK_HEIGHT + 0.1;
+
+    // Approach
+    moveArm(left_arm_client, l_move_group, box_pickup_pose, GOAL_TIME_TOLERANCE); // Commented out to try
+    actuateGripper(left_gripper_client, OPEN_POS, MAX_EFFORT);
+
+    box_pickup_pose.position.x = 0.8 - PRE_GRASP_DISTANCE;
+
+    // Ready for pickup
+    moveArm(left_arm_client, l_move_group, box_pickup_pose, GOAL_TIME_TOLERANCE * 0.5);
+
+    // Re-orient
+    moveArm(left_arm_client, l_move_group, box_pickup_pose, GOAL_TIME_TOLERANCE);
+
+    std::vector<std::string> object_ids;
+    object_ids.push_back("pickup_box");
+    object_ids.push_back("pickup_cylinder");
+
+    // planning_scene_interface.removeCollisionObjects(object_ids);
+
+    actuateGripper(left_gripper_client, CLOSE_POS, MAX_EFFORT);
+
+    geometry_msgs::PoseStamped left_end_pose;
+
+    while (ros::ok){
+      left_end_pose = l_move_group.getCurrentPose("left_gripper_link");
+
+      ROS_INFO("POSE REPORT:");
+      ROS_INFO("ORI w: %f", left_end_pose.pose.orientation.w);
+      ROS_INFO("ORI x: %f", left_end_pose.pose.orientation.x);
+      ROS_INFO("ORI y: %f", left_end_pose.pose.orientation.y);
+      ROS_INFO("ORI z: %f", left_end_pose.pose.orientation.z);
+
+      ROS_INFO("POS x: %f", left_end_pose.pose.position.x);
+      ROS_INFO("POS y: %f", left_end_pose.pose.position.y);
+      ROS_INFO("POS z: %f", left_end_pose.pose.position.z);
+
+      ros::Duration(3).sleep();
+    }
+
+    // std::copy(l_move_group.getJointNames().begin(), l_move_group.getJointNames().end(),
+    //       std::ostream_iterator<std::string>(std::cout, ", "));
+
+    return 0;
+}

--- a/blue_moveit_scenarios/src/pick_and_place.cpp
+++ b/blue_moveit_scenarios/src/pick_and_place.cpp
@@ -57,8 +57,8 @@ int main(int argc, char **argv)
     ROS_INFO("Gripper action clients ready!");
 
     // Init Arm action clients
-    actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> right_arm_client("right_arm/blue_controllers/joint_torque_controller/follow_joint_trajectory", true);
-    actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> left_arm_client("left_arm/blue_controllers/joint_torque_controller/follow_joint_trajectory", true);
+    actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> right_arm_client("right_arm/blue_controllers/joint_trajectory_controller/follow_joint_trajectory", true);
+    actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> left_arm_client("left_arm/blue_controllers/joint_trajectory_controller/follow_joint_trajectory", true);
 
     left_arm_client.waitForServer();
     right_arm_client.waitForServer();

--- a/blue_moveit_scenarios/src/pick_and_place.cpp
+++ b/blue_moveit_scenarios/src/pick_and_place.cpp
@@ -1,4 +1,11 @@
 #include "moveit_arm_utils.h"
+#include <csignal>
+
+void signal_handler( int signal_num ) {
+   // Terminate program
+   ros::shutdown();
+   exit(signal_num);
+}
 
 // Gripper params
 const double CLOSE_POS(0.61);
@@ -12,7 +19,7 @@ const double BASE_LINK_HEIGHT(0.965);
 ros::Duration GOAL_TIME_TOLERANCE(15.0);
 const double GOAL_TOLERANCE(0.025);
 const double PRE_GRASP_APPROACH_DISTANCE(0.10);
-const double PRE_GRASP_DISTANCE(0.04);
+const double PRE_GRASP_DISTANCE(0.06);
 const double POST_GRASP_RETREAT_DISTANCE(0.10);
 
 int main(int argc, char **argv)
@@ -23,6 +30,9 @@ int main(int argc, char **argv)
     // Init ROS
     ros::init(argc, argv, "pick_and_place_commander");
     ros::NodeHandle nh;
+
+    // Bind signal handler
+    std::signal(SIGINT, signal_handler);
 
     // Start async spinner to facilitate joint-state publishing
     ros::AsyncSpinner spinner(1);

--- a/blue_moveit_scenarios/src/pick_and_place.cpp
+++ b/blue_moveit_scenarios/src/pick_and_place.cpp
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
     object_ids.push_back("pickup_box");
     object_ids.push_back("pickup_cylinder");
 
-    // planning_scene_interface.removeCollisionObjects(object_ids);
+    planning_scene_interface.removeCollisionObjects(object_ids);
 
     actuateGripper(left_gripper_client, CLOSE_POS, MAX_EFFORT);
 


### PR DESCRIPTION
I changed several packages in the entire Blue stack to work with MoveIt! Gazebo.

### Edited packages
- blue_core
- blue_moveit
- blue_simulator

### Related PRs
- https://github.com/berkeleyopenarms/blue_simulator/pull/5#issue-281898034
- https://github.com/berkeleyopenarms/blue_moveit/pull/2#issue-281898515
- https://github.com/berkeleyopenarms/blue_core/pull/51#issue-281897805

### PR Specific Description
I fixed some typos and cleaned up the package a bit.

I also added a Gazebo launchfile for demoing the arm stack with Gazebo, and a package for running demo-scenarios with the Blue stack. That particular package has a node for automating a pick and place demo.

Note: Gazebo crashes if the picked up object collides with the mimic joints. This is unavoidable unless the plugin is swapped out for another one as the plugin works by applying instantaneous forces to the grippers to simulate the mimic joint.