### PR TITLE
Bug: Fix utils namespace clash

### DIFF
--- a/blue_moveit_demos/CMakeLists.txt
+++ b/blue_moveit_demos/CMakeLists.txt
@@ -49,13 +49,13 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_library(moveit_arm_utils include/moveit_arm_utils.cpp)
+add_library(demo_moveit_arm_utils include/demo_moveit_arm_utils.cpp)
 
 add_executable(pick_and_place src/pick_and_place.cpp)
-target_link_libraries(pick_and_place moveit_arm_utils ${catkin_LIBRARIES})
+target_link_libraries(pick_and_place demo_moveit_arm_utils ${catkin_LIBRARIES})
 
 add_executable(right_table_pick_and_place src/right_table_pick_and_place.cpp)
-target_link_libraries(right_table_pick_and_place moveit_arm_utils ${catkin_LIBRARIES})
+target_link_libraries(right_table_pick_and_place demo_moveit_arm_utils ${catkin_LIBRARIES})
 
-add_dependencies(pick_and_place moveit_arm_utils ${blue_moveit_gazebo_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-add_dependencies(right_table_pick_and_place moveit_arm_utils ${blue_moveit_gazebo_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(pick_and_place demo_moveit_arm_utils ${blue_moveit_gazebo_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(right_table_pick_and_place demo_moveit_arm_utils ${blue_moveit_gazebo_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/blue_moveit_demos/include/demo_moveit_arm_utils.cpp
+++ b/blue_moveit_demos/include/demo_moveit_arm_utils.cpp
@@ -1,4 +1,4 @@
-#include "moveit_arm_utils.h"
+#include "demo_moveit_arm_utils.h"
 
 void actuateGripper(actionlib::SimpleActionClient<control_msgs::GripperCommandAction>& ac, double position, double max_effort)
 {

--- a/blue_moveit_demos/include/demo_moveit_arm_utils.h
+++ b/blue_moveit_demos/include/demo_moveit_arm_utils.h
@@ -1,5 +1,5 @@
-#ifndef MOVEIT_ARM_UTILS
-#define MOVEIT_ARM_UTILS
+#ifndef DEMO_MOVEIT_ARM_UTILS
+#define DEMO_MOVEIT_ARM_UTILS
 
 // ROS
 #include <ros/ros.h>

--- a/blue_moveit_demos/src/pick_and_place.cpp
+++ b/blue_moveit_demos/src/pick_and_place.cpp
@@ -1,4 +1,4 @@
-#include "moveit_arm_utils.h"
+#include "demo_moveit_arm_utils.h"
 #include <csignal>
 
 void signal_handler( int signal_num ) {

--- a/blue_moveit_demos/src/right_table_pick_and_place.cpp
+++ b/blue_moveit_demos/src/right_table_pick_and_place.cpp
@@ -1,4 +1,4 @@
-#include "moveit_arm_utils.h"
+#include "demo_moveit_arm_utils.h"
 #include <csignal>
 
 void signal_handler( int signal_num ) {


### PR DESCRIPTION
This PR fixes a bug that is introduced if building with `catkin_make` instead of `catkin build`.

As all libraries that are built using `catkin_make` are visible when building all other packages, it causes a clash in the moveit_arm_utils library that is built here and with the `blue_helpers` package, which also features a library called moveit_arm_utils.

This change should fix that.